### PR TITLE
Add 8-digit check for phone number

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,13 @@
       <h2>Pago por Horas</h2>
 
       <label for="telefono">Número de teléfono del destinatario:</label>
-      <input type="tel" id="telefono" value="85696483" />
+      <input
+        type="tel"
+        id="telefono"
+        value="85696483"
+        pattern="\d{8}"
+        maxlength="8"
+      />
 
       <label for="descripcion">Descripción:</label>
       <input type="text" id="descripcion" value="Limpieza" />

--- a/script.js
+++ b/script.js
@@ -32,6 +32,12 @@ function calcular() {
     return;
   }
 
+  if (!soloDigitos.test(destinatario) || destinatario.length !== 8) {
+    document.getElementById("resultado").textContent =
+      "El número de teléfono debe tener 8 dígitos.";
+    return;
+  }
+
   if (!soloDigitos.test(monto)) {
     document.getElementById("resultado").textContent =
       "El monto debe contener solo números.";


### PR DESCRIPTION
## Summary
- constrain recipient phone input to 8 digits
- validate recipient phone in JS

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6857085efaac832db31a1478edaff7cd